### PR TITLE
Fix off-by-one in month numbers

### DIFF
--- a/dateformat.js
+++ b/dateformat.js
@@ -52,7 +52,7 @@
             A : am.toUpperCase(),
             y : (""+year).substr(2,2),
             c : t.toISOString(),
-            m: lz(month),
+            m: lz(month + 1),
             U: Math.round(t/1000),
             g: hours12,
             G: lz(hours12),


### PR DESCRIPTION
Hi!

I've been using your library and it's been working great, but I feel like it should behave more like PHP's date() and return 1-based month numbers rather than 0-based.

moment.js, https://github.com/tiger-seo/date.format, and https://github.com/firstandthird/datefmt all do this.

    (new Date).format('M')
    (new Date).format('m')

Output:

    "May"
    "04"
